### PR TITLE
tests: Build Inline code in a temporary directory

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,6 +8,7 @@ WriteMakefile(
     'ExtUtils::MakeMaker' => 6.48,
   },
   TEST_REQUIRES => {
+    'File::Temp' => 0,
     'Inline' => 0.66,
     'Inline::C' => 0.62,
     'Test::More' => 0.88,

--- a/t/all.t
+++ b/t/all.t
@@ -1,6 +1,6 @@
 use Test::More;
 use lib '.';
-require 't/common.pl';
+BEGIN { require 't/common.pl'; }
 
 use Inline C => <<'END', structs => 1, force_build => 1;
 struct Foo {

--- a/t/anon.t
+++ b/t/anon.t
@@ -1,6 +1,6 @@
 use Test::More;
 use lib '.';
-require 't/common.pl';
+BEGIN { require 't/common.pl'; }
 
 use Inline C => <<'END', structs => 1, force_build => 1;
 typedef struct {

--- a/t/argorder.t
+++ b/t/argorder.t
@@ -1,4 +1,5 @@
 use Test::More;
+BEGIN { require './t/common.pl'; }
 
 use Inline C => config => inc => q{-DNUMBER=16}, structs => 1;
 use Inline C => <<EOF, force_build => 1;

--- a/t/common.pl
+++ b/t/common.pl
@@ -1,5 +1,10 @@
 use Test::More;
 
+# Build in unique directories to enable parallel and read-only tests.
+use File::Temp;
+my $tmp_dir;
+use Inline Config => directory => ($tmp_dir = File::Temp->newdir());
+
 # assumes suitable class setup before call
 sub run_struct_tests {
   my $class = 'Inline::Struct::'.($_[0]||'Foo');

--- a/t/copyref.t
+++ b/t/copyref.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+BEGIN { require './t/common.pl'; }
 
 use Inline C => <<'END', structs => 1, force_build => 1;
 struct Foo {

--- a/t/enum.t
+++ b/t/enum.t
@@ -1,6 +1,6 @@
 use Test::More;
 use lib '.';
-require 't/common.pl';
+BEGIN { require 't/common.pl'; }
 
 use Inline C => <<'END', structs => 1, force_build => 1;
 struct Foo {

--- a/t/funcptr.t
+++ b/t/funcptr.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+BEGIN { require './t/common.pl'; }
 
 use Inline C => Config => force_build => 1;
 use Inline C => 'DATA', structs => [qw(aaa_t bbb_t)];

--- a/t/multi.t
+++ b/t/multi.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+BEGIN { require './t/common.pl'; }
 
 use Inline C => Config => force_build => 1;
 use Inline C => 'DATA', structs => ['aaa_t','bbb_t'];

--- a/t/oneline.t
+++ b/t/oneline.t
@@ -1,4 +1,5 @@
 use Test::More;
+BEGIN { require './t/common.pl'; }
 
 use Inline C => config => structs => 1;
 ok(Inline->bind(C => 'struct Foo {int i;};', force_build => 1));

--- a/t/readme.t
+++ b/t/readme.t
@@ -1,4 +1,5 @@
 use Test::More;
+BEGIN { require './t/common.pl'; }
 
 use Inline C => 'DATA', structs => ['JA_H'], force_build => 1;
 

--- a/t/refcnt.t
+++ b/t/refcnt.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+BEGIN { require './t/common.pl'; }
 
 use Inline C => <<'END', structs => 1, force_build => 1;
 struct Foo {

--- a/t/selfref.t
+++ b/t/selfref.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+BEGIN { require './t/common.pl'; }
 
 use Inline;
 eval { Inline->bind(C => <<'END', structs => 1, force_build => 1, clean_after_build => 0) };

--- a/t/srcmember.t
+++ b/t/srcmember.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+BEGIN { require './t/common.pl'; }
 
 use Inline;
 eval { Inline->bind(C => <<'END', structs => 1, force_build => 1) };

--- a/t/svmember.t
+++ b/t/svmember.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+BEGIN { require './t/common.pl'; }
 
 use Inline C => <<'END', structs => 1, force_build => 1;
 struct Foo {

--- a/t/synopsis.t
+++ b/t/synopsis.t
@@ -1,4 +1,5 @@
 use Test::More;
+BEGIN { require './t/common.pl'; }
 
 use Inline C => 'DATA', structs => ['Foo'], force_build => 1;
 

--- a/t/types.t
+++ b/t/types.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+BEGIN { require './t/common.pl'; }
 
 use Inline C => Config => force_build => 1;
 use Inline C => 'DATA', structs => ['aaa_t','bbb_t'];


### PR DESCRIPTION
Previously, the tests could not gain any benefit from running in
parallel because Inline builds all code in the same _Inline directory
which it locks before use. Hence all tests were always serialized.

Also the tests failed when running from a read-only location:

    $ perl -I. t/all.t
    Couldn't find an appropriate DIRECTORY for Inline to use.

     at t/all.t line 5.
    BEGIN failed--compilation aborted at t/all.t line 5.

This patch fixes both the issues by configuring Inline to use
a directory unique for each test:

    $ prove -j5 t
    t/all.t ........ ok
    [...]
    t/types.t ...... ok
    All tests successful.
    Files=15, Tests=70, 10 wallclock secs ( 0.06 usr  0.04 sys + 22.34 cusr 13.86 csys = 36.30 CPU)
    Result: PASS